### PR TITLE
Release 17-08-2022: data type support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 ## Custom Data
 
-A package that minimize mixed arguments of functions or class methods
+A package that chase the delcaration of many arguments to a functions or class methods
 
-Whenever i see a function with argument `$data` i'm like 🤮, because i have to activate my prophetic side to guess which king of data is provided. so i decided to make this package so that you can start defining your arguments like
+Whenever i see a function with argument `($data1, $data2...)` i'm like 🤮, because i have to activate my prophetic side to guess which king of data is being provided. so i decided to make this package so that you can start defining your arguments like
 
 ```php
 function handle(CreateUserData $data) {
@@ -91,6 +91,63 @@ class CreateUserAction
         // then do whatever you wanna do here
     }
 }
+
+```
+
+## Support of One class One Responsability( ==> Action😎)
+
+For people who like to split their business logic into small classes called `action`, here is your chocolate,
+
+```php
+//Before
+
+//defining action that use CustomData parameters
+
+class MyAction
+{
+    public static function handle(MyActionData $data) {
+
+    }
+}
+
+
+// call the action
+
+
+MyAction::handle(MyActionData::make([
+    'arg1' => value,
+    'arg2' => value,
+    'arg3' => value
+    ...
+]));
+
+```
+
+Can you imagine you have to call your `CustomData`(MyActionData) wherever you are using yoour actioon, that's too much🤮 🤮 🤮 🤮 . Now the good news is that, you can extends the `Kakaprodo\CustomData\Helpers\CustomActionBuilder` class to your action and then, it will do for you the injection magic of your customData using its `process` method. (What?😳, Noooo way😎!).
+
+```php
+//After
+
+//defining action that use CustomData parameters
+
+use Kakaprodo\CustomData\Helpers\CustomActionBuilder;
+
+class MyAction extends CustomActionBuilder
+{
+    public static function handle(MyActionData $data) {
+
+    }
+}
+
+
+// call the action without defining  MyActionData class
+
+MyAction::process([
+    'arg1' => value,
+    'arg2' => value,
+    'arg3' => value
+    ...
+]);
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -80,6 +80,40 @@ Just add the expected properties in your `expectedProperties`, and add a suffix 
     }
 ```
 
+### Data type support
+
+This package allows you to define data type on your expected properties like bellow:
+
+```php
+    protected function expectedProperties(): array
+    {
+        return [
+            'name' => $this->dataType()->string()
+            'price' => $this->dataType()->numeric()
+            'user' => $this->dataType(\Customer\Path\User::class)
+        ];
+    }
+```
+
+You can also define a default value of an expected property
+
+```php
+    protected function expectedProperties(): array
+    {
+        return [
+            'price?' => $this->dataType()->numeric(100)
+            // Or
+            'name?' => $this->dataType()->string()->default('kakaprodo')
+        ];
+    }
+```
+
+Here is the list of the supported data type so far:
+
+-   string: `$this->dataType()->string()`
+-   numeric: `$this->dataType()->numeric()`
+-   bool : `$this->dataType()->bool()`
+
 ### Use your Data class inside an action
 
 ```php
@@ -94,7 +128,7 @@ class CreateUserAction
 
 ```
 
-## Support of One class One Responsability( ==> Action😎)
+## Support Customer Data Injection
 
 For people who like to split their business logic into small classes called `action`, here is your chocolate,
 

--- a/src/CustomData.php
+++ b/src/CustomData.php
@@ -3,9 +3,11 @@
 namespace Kakaprodo\CustomData;
 
 use Exception;
+use Kakaprodo\CustomData\Lib\CustomDataBase;
+use Kakaprodo\CustomData\Lib\TypeHub\DataTypeHub;
 use Kakaprodo\CustomData\Traits\HasCustomDataHelper;
 
-abstract class CustomData
+abstract class CustomData extends CustomDataBase
 {
     use HasCustomDataHelper;
 
@@ -45,14 +47,6 @@ abstract class CustomData
     }
 
     /**
-     * Required  class properties 
-     * 
-     * Note: when defining property, use  the suffix `?` to 
-     * your property for defining it as optional
-     */
-    abstract protected function expectedProperties(): array;
-
-    /**
      * All data passed to the class
      */
     public function all(): array
@@ -65,20 +59,23 @@ abstract class CustomData
         return $this->data[$name] ?? null;
     }
 
-    /**
-     * Check if all required properties were provided
-     */
-    private function validateRequiredProperties()
+    public function __set($name, $value)
     {
+        return $this->data[str_replace('?', '', $name)] = $value;
+    }
 
-        foreach ($this->expectedProperties() as $property) {
+    /**
+     * get a given property with the ability to pass
+     * a default in case the property is not defined
+     */
+    public function get($property, $default = null)
+    {
+        $value = $this->{$property};
 
-            // if a property is optional
-            if ($this->strEndsWith($property, '?')) continue;
+        if ($value || !$default) return $value;
 
-            if ($this->{$property} == null) throw new Exception(
-                "The property {$property} is required on the class " . static::class
-            );
-        }
+        $this->{$property} = $default;
+
+        return $default;
     }
 }

--- a/src/Helpers/CustomActionBuilder.php
+++ b/src/Helpers/CustomActionBuilder.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Kakaprodo\CustomData\Helpers;
+
+use Exception;
+use ReflectionMethod;
+use Kakaprodo\CustomData\CustomData;
+
+abstract class CustomActionBuilder
+{
+    public static function process(
+        array $data,
+        ?callable $beforeDataBoot = null
+    ) {
+        $action = (new static());
+
+        if (!method_exists($action, 'handle')) {
+            throw new Exception(
+                "Your action " . get_class($action) . " should have a handle method"
+            );
+        }
+
+        $customDataClass = self::getActionHandleDataClass($action);
+
+        $customData = $customDataClass::make(...func_get_args());
+
+        return $action->handle($customData, $beforeDataBoot);
+    }
+
+    /**
+     * Detect the custom data class of the argument of the actual 
+     * Action::handle method
+     * 
+     * @return string
+     */
+    public static function getActionHandleDataClass(CustomActionBuilder $action)
+    {
+
+        $actionHandleMethod = new ReflectionMethod($action, 'handle');
+        $actionHandleParams = $actionHandleMethod->getParameters();
+
+        if (!count($actionHandleParams)) {
+            throw new Exception(
+                "Your action " . get_class($action) . "::handle is supposed to have an arguments"
+            );
+        }
+
+        $argumentName = ($actionHandleParams[0])->getName();
+        $customDataReflection = ($actionHandleParams[0])->getType();
+
+        if (!$customDataReflection) {
+            throw new Exception(
+                "Your action " . get_class($action) . "::handle's argument \${$argumentName} is missing a customData type"
+            );
+        }
+
+        if ($customDataReflection->isBuiltIn()) {
+            throw new Exception(
+                "Your action " . get_class($action) . "::handle's argument \${$argumentName} should use a custom data type"
+            );
+        }
+
+        $customDataClass = $customDataReflection->getName();
+
+        if (!(new $customDataClass([]) instanceof CustomData)) {
+            throw new Exception(
+                "The class {$customDataClass} should extend " . CustomData::class
+            );
+        }
+
+        return $customDataClass;
+    }
+}

--- a/src/Lib/CustomDataBase.php
+++ b/src/Lib/CustomDataBase.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Kakaprodo\CustomData\Lib;
+
+use Exception;
+use Kakaprodo\CustomData\Lib\Optional;
+use Kakaprodo\CustomData\Lib\TypeHub\DataTypeHub;
+
+abstract class CustomDataBase
+{
+    /**
+     * Required  class properties 
+     * 
+     * Note: when defining property, use  the suffix `?` to 
+     * your property for defining it as optional
+     */
+    abstract protected function expectedProperties(): array;
+
+    /**
+     * define a type of a given property 
+     */
+    public function dataType($customerType = null): DataTypeHub
+    {
+        return new DataTypeHub($this, $customerType);
+    }
+
+    public function optional($object)
+    {
+        return new Optional($object);
+    }
+
+    /**
+     * Validatee properties
+     */
+    protected function validateRequiredProperties()
+    {
+
+        foreach ($this->expectedProperties() as $propertyName => $propertyValue) {
+
+            // in case data type checking is not supported
+            $propertyName = is_numeric($propertyName) ? $propertyValue : $propertyName;
+
+            $shouldCheckDataType = ($propertyValue instanceof DataTypeHub);
+
+            // if a property is optional
+            if ($this->strEndsWith($propertyName, '?')) {
+
+                if ($shouldCheckDataType) $propertyValue->validate($propertyName);
+
+                continue;
+            }
+
+            $valueForRequiredValidation = $this->get(
+                $propertyName,
+                $shouldCheckDataType ? $propertyValue->default : null
+            );
+
+            if ($valueForRequiredValidation == null) throw new Exception(
+                "The property {$propertyName} is required on the class " . static::class
+            );
+
+            // validate the property type
+            if ($shouldCheckDataType) $propertyValue->validate($propertyName);
+        }
+    }
+}

--- a/src/Lib/Optional.php
+++ b/src/Lib/Optional.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Kakaprodo\CustomData\Lib;
+
+
+class Optional
+{
+    protected $object = null;
+
+    public function __construct($object)
+    {
+        $this->object = $object;
+    }
+
+    public function __call($name, $arguments)
+    {
+        if (!$this->object && !is_object($this->object)) return null;
+
+        return method_exists($this->object, $name) ?
+            $this->object->{$name}($arguments)
+            : null;
+    }
+
+    public function __get($name)
+    {
+        if (!$this->object && !is_object($this->object)) return null;
+
+        return  $this->object->{$name} ?? null;
+    }
+}

--- a/src/Lib/TypeHub/DataTypeHub.php
+++ b/src/Lib/TypeHub/DataTypeHub.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace Kakaprodo\CustomData\Lib\TypeHub;
+
+use Exception;
+use ReflectionClass;
+use Kakaprodo\CustomData\Lib\CustomDataBase;
+
+class DataTypeHub
+{
+    const DATA_NUMERIC = 'numeric';
+    const DATA_BOOL = 'bool';
+    const DATA_STRING = 'string';
+
+    protected $selectedType = null;
+
+    /**
+     * @var CustomDataBase
+     */
+    protected $customData;
+
+    public $default = null;
+
+    public function __construct(CustomDataBase $customData, $type = null)
+    {
+        $this->customData = $customData;
+        $this->selectedType = $type;
+    }
+
+    /**
+     * define that a property is a number
+     */
+    public function numeric($default = null)
+    {
+        $this->selectedType = self::DATA_NUMERIC;
+
+        return $this->default($default);
+    }
+
+    /**
+     * define that a property is a boolean
+     */
+    public function bool($default = null)
+    {
+        $this->selectedType = self::DATA_BOOL;
+
+        return $this->default($default);
+    }
+
+    /**
+     * define that a property is a string
+     */
+    public function string($default = null)
+    {
+        $this->selectedType = self::DATA_STRING;
+
+        return $this->default($default);
+    }
+
+    /**
+     * Set a default value of a data type
+     */
+    public function default($default = null)
+    {
+        $this->default = $default;
+
+        return $this;
+    }
+
+    /**
+     * check if a selected type is a custoomer data Type
+     */
+    private function isCustomType()
+    {
+        $builtInTypes = (new ReflectionClass($this))->getConstants();
+
+        return !in_array($this->selectedType, $builtInTypes);
+    }
+
+    /**
+     * validate the customData's property type
+     */
+    public function validate($propertyName)
+    {
+        if (!$this->selectedType)  throw new Exception(
+            "No data type was defined for the property {$propertyName} "
+        );
+
+        $propertyValue = $this->customData->get($propertyName, $this->default);
+
+        $isCustomType = $this->isCustomType();
+
+        $typeMatches = !$isCustomType ?
+            "is_{$this->selectedType}"($propertyValue)
+            : ($propertyValue instanceof ($this->selectedType));
+
+        if (!$typeMatches) throw new Exception(
+            "Property {$propertyName}: Expected {$this->selectedType} but " .
+                gettype($propertyValue) . " given"
+        );
+    }
+}


### PR DESCRIPTION
This package allows you to define data type on your expected properties like bellow:

```php
    protected function expectedProperties(): array
    {
        return [
            'name' => $this->dataType()->string()
            'price' => $this->dataType()->numeric()
            'user' => $this->dataType(\Customer\Path\User::class)
        ];
    }
```