### PR TITLE
Nested data - props : provided a way to pass additional properties to child data from parent validation

### DIFF
--- a/src/Helpers/VirtualCustomData.php
+++ b/src/Helpers/VirtualCustomData.php
@@ -27,7 +27,7 @@ class VirtualCustomData extends CustomData
     public static  function  check(
         callable $myValidationClosure,
         $data = [],
-        callable $errors = null
+        ?callable $errors = null
     ): CustomData {
         $virtual = new static($data);
 

--- a/src/Lib/Base/DataPropertyAbstract.php
+++ b/src/Lib/Base/DataPropertyAbstract.php
@@ -50,6 +50,11 @@ abstract class DataPropertyAbstract
     public $default = null;
 
     /**
+     * Properties to pass to a child custom-data class
+     */
+    public $childProps = [];
+
+    /**
      * The basic nature of a property
      */
     const PROPERTY_NATURE_REQUIRED = "required";
@@ -60,13 +65,15 @@ abstract class DataPropertyAbstract
      */
     const ACTION_GENERAL = 'GENERAL';
     const ACTION_WRAPPER = 'WRAPPER';
+    const ACTION_EXTRA = 'EXTRA';
 
     /**
      * the lifecycle of action execution
      */
     static $eventExecutionOrders = [
         self::ACTION_GENERAL,
-        self::ACTION_WRAPPER
+        self::ACTION_WRAPPER,
+        self::ACTION_EXTRA,
     ];
 
     /**
@@ -136,7 +143,7 @@ abstract class DataPropertyAbstract
      * Register an action task that will be executed before auditing 
      * a property
      */
-    protected function addBeforeAuditAction(callable $actionHandler, string $groupAction = null)
+    public function addBeforeAuditAction(callable $actionHandler, ?string $groupAction = null)
     {
         $this->beforeAuditActions[$groupAction ?? self::ACTION_GENERAL][] = $actionHandler;
 
@@ -147,7 +154,7 @@ abstract class DataPropertyAbstract
      * Register an action task that will be executed after auditing 
      * a property
      */
-    protected function addAfterAuditAction(callable $actionHandler, string $groupAction = null)
+    public function addAfterAuditAction(callable $actionHandler, ?string $groupAction = null)
     {
         $this->afterAuditActions[$groupAction ?? self::ACTION_GENERAL][] = $actionHandler;
 
@@ -212,6 +219,14 @@ abstract class DataPropertyAbstract
     public function getType()
     {
         return $this->selectedType;
+    }
+
+    /**
+     * Get the name of the property
+     */
+    public function getPropertyName()
+    {
+        return $this->propertyName;
     }
 
     /**

--- a/src/Lib/Base/Traits/HasDataTypeHubHelper.php
+++ b/src/Lib/Base/Traits/HasDataTypeHubHelper.php
@@ -61,7 +61,7 @@ trait HasDataTypeHubHelper
 
         if (!CustomData::isCustomDataChild($type)) return $value;
 
-        return $type::make($value);
+        return $type::make(array_merge($this->childProps, $value));
     }
 
 
@@ -71,13 +71,13 @@ trait HasDataTypeHubHelper
     public function typeOfValueIs($type, $value, $customType = null)
     {
         $typeChecker = [
-            self::DATA_STRING => fn () => is_string($value) || is_numeric($value),
-            self::DATA_INT => fn () => is_integer($value),
-            self::DATA_FLOAT => fn () => is_float($value),
-            self::DATA_BOOL => fn () => is_bool($value) || in_array(intval($value), [0, 1], true),
-            self::DATA_ARRAY => fn () => is_array($value) && $this->arrayItemsAreCompatible($value, $customType),
-            self::DATA_OBJECT => fn () => is_object($value),
-            self::DATA_NUMERIC => fn () => is_numeric($value),
+            self::DATA_STRING => fn() => is_string($value) || is_numeric($value),
+            self::DATA_INT => fn() => is_integer($value),
+            self::DATA_FLOAT => fn() => is_float($value),
+            self::DATA_BOOL => fn() => is_bool($value) || in_array(intval($value), [0, 1], true),
+            self::DATA_ARRAY => fn() => is_array($value) && $this->arrayItemsAreCompatible($value, $customType),
+            self::DATA_OBJECT => fn() => is_object($value),
+            self::DATA_NUMERIC => fn() => is_numeric($value),
             self::DATA_CUSTOM => function () use ($value, $customType) {
 
                 if (CustomData::isCallable($customType)) {

--- a/src/Lib/CustomDataBase.php
+++ b/src/Lib/CustomDataBase.php
@@ -73,7 +73,7 @@ abstract class CustomDataBase
      * 
      * @return Wrapper | array
      */
-    public function wrapper(string $groupName = null)
+    public function wrapper(?string $groupName = null)
     {
         $wrapper = new Wrapper($this);
 

--- a/src/Lib/Property/DataProperty.php
+++ b/src/Lib/Property/DataProperty.php
@@ -2,6 +2,7 @@
 
 namespace Kakaprodo\CustomData\Lib\Property;
 
+use Closure;
 use Illuminate\Support\Str;
 use Kakaprodo\CustomData\CustomData;
 use Kakaprodo\CustomData\Lib\CustomDataBase;
@@ -24,7 +25,7 @@ class DataProperty extends DataTypeHub
     public function toCamelCase()
     {
         $this->addBeforeAuditAction(
-            fn () => $this->transform(fn () => Str::camel($this->propertyName))
+            fn() => $this->transform(fn() => Str::camel($this->propertyName))
         );
 
         return $this;
@@ -36,7 +37,7 @@ class DataProperty extends DataTypeHub
     public function toKebabCase()
     {
         $this->addBeforeAuditAction(
-            fn () => $this->transform(fn () => Str::kebab($this->propertyName))
+            fn() => $this->transform(fn() => Str::kebab($this->propertyName))
         );
 
         return $this;
@@ -48,7 +49,7 @@ class DataProperty extends DataTypeHub
     public function toSnakeCase()
     {
         $this->addBeforeAuditAction(
-            fn () => $this->transform(fn () => Str::snake($this->propertyName))
+            fn() => $this->transform(fn() => Str::snake($this->propertyName))
         );
 
         return $this;
@@ -60,7 +61,7 @@ class DataProperty extends DataTypeHub
     public function toPascalCase()
     {
         $this->addBeforeAuditAction(
-            fn () => $this->transform(function () {
+            fn() => $this->transform(function () {
                 $str = ucwords(preg_replace('/[^a-zA-Z0-9]+/', ' ', $this->propertyName));
 
                 return str_replace(' ', '', $str);
@@ -141,7 +142,7 @@ class DataProperty extends DataTypeHub
     public function castToModel(
         string $fullyClassName,
         string $column = 'id',
-        string $errorMessage = null
+        ?string $errorMessage = null
     ) {
         return $this->castTo(function () use ($fullyClassName, $column, $errorMessage) {
             if (!($value = $this->value())) return;
@@ -163,7 +164,7 @@ class DataProperty extends DataTypeHub
      */
     public function copy($copyName = null, $shouldReplaceProperty = false)
     {
-        $this->addAfterAuditAction(fn () => $this->copyPropertyValue($copyName, $shouldReplaceProperty));
+        $this->addAfterAuditAction(fn() => $this->copyPropertyValue($copyName, $shouldReplaceProperty));
 
         return $this;
     }
@@ -188,9 +189,33 @@ class DataProperty extends DataTypeHub
     public function wrap(string $groupName)
     {
         $this->addAfterAuditAction(
-            fn () => $this->customData->wrapper()->add($groupName, $this->propertyName),
+            fn() => $this->customData->wrapper()->add($groupName, $this->propertyName),
             self::ACTION_WRAPPER
         );
+
+        return $this;
+    }
+
+    /**
+     * Pass additional properties to a child custom-data
+     */
+    public function props($childProps)
+    {
+        $this->addBeforeAuditAction(
+            fn() => $this->childProps = CustomData::isCallable($childProps)
+                ? $childProps($this)
+                : $childProps
+        );
+
+        return $this;
+    }
+
+    /**
+     * Add an additional task to execute on the property 
+     */
+    public function addTask(Closure $myCallback)
+    {
+        $this->addAfterAuditAction(fn() => $myCallback($this));
 
         return $this;
     }


### PR DESCRIPTION
## Work done
Now you can pass down props to child custom-data
```php
    protected function expectedProperties(): array
    {
        'order' => $this->property(OrderModel::class),
        'order_items' => $this->property()
                  ->isArrayOf(CreateOrderItemData::class)
                  ->props(fn() => ['order_id' => $this->order->id]),
    }
```